### PR TITLE
Fixing old eigen link that no longer exists

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -20,10 +20,10 @@ RUN apk update && \
     g++ \
     make \
     upx \
-    mercurial \
+    git \
     linux-headers
 
-RUN hg clone https://bitbucket.org/eigen/eigen && cd eigen && mkdir build && cd build && cmake .. && make -j4 install
+RUN git clone --depth=1 https://gitlab.com/libeigen/eigen.git && cd eigen && mkdir build && cd build && cmake .. && make -j4 install
 
 ADD . /opt/sources
 WORKDIR /opt/sources

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -26,9 +26,9 @@ RUN apk update && \
     cmake \
     g++ \
     make \
-    mercurial
+    git
 
-RUN hg clone https://bitbucket.org/eigen/eigen && cd eigen && mkdir build && cd build && cmake .. && make -j4 install
+RUN git clone --depth=1 git clone https://gitlab.com/libeigen/eigen.git && cd eigen && mkdir build && cd build && cmake .. && make -j4 install
 
 ADD . /opt/sources
 WORKDIR /opt/sources


### PR DESCRIPTION
Eigen has migrated from bitbucket to GitLab. The old hosted link is no longer valid.